### PR TITLE
Returning closet match

### DIFF
--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -27,9 +27,10 @@ try:
     import openmc
 except ImportError:
     OPENMC_AVAILABLE = False
-    warnings.warn(
-        "OpenMC python package not found, .openmc_material, .serpent_material, \
-            .mcnp_material, .fispact_material methods not avaiable")
+    msg = ("OpenMC python package not found, .openmc_material, "
+           ".serpent_material, .mcnp_material, .fispact_material methods not "
+           "avaiable")
+    warnings.warn(msg)
 
 atomic_mass_unit_in_g = 1.660539040e-24
 
@@ -488,7 +489,7 @@ class Material:
             self._density = value
         elif isinstance(value, (int, float)):
             if value < 0:
-                raise ValueError("Material.density should be above 0", value)
+                raise ValueError(f"Material.density should be above 0. Not {value}")
             self._density = float(value)
 
     @property
@@ -523,11 +524,9 @@ class Material:
     def enrichment_target(self, value):
         if value is not None:
             if value not in NATURAL_ABUNDANCE.keys():
-                raise ValueError(
-                    "Material.enrichment_target must be a naturally occuring "
-                    "isotope from this list",
-                    NATURAL_ABUNDANCE.keys(),
-                )
+                msg = ("Material.enrichment_target must be a naturally occuring "
+                       f"isotope from this list {NATURAL_ABUNDANCE.keys()}")
+                raise ValueError(msg)
         self._enrichment_target = value
 
     @property
@@ -544,8 +543,7 @@ class Material:
     def pressure(self, value):
         if value is not None:
             if value < 0.0:
-                raise ValueError(
-                    "Material.pressure must be greater than 0")
+                raise ValueError("Material.pressure must be greater than 0")
         self._pressure = value
 
     @property
@@ -800,14 +798,10 @@ class Material:
 
             self.density = mass / self.volume_of_unit_cell_cm3
         else:
-
-            raise ValueError(
-                "density can't be set for "
-                + str(self.name) +
-                " provide either a density value as a number or density "
-                "as a string, or atoms_per_unit_cell and "
-                "volume_of_unit_cell_cm3"
-            )
+            msg = ("density can't be set for {self.name} provide either a "
+                   "density value as a number or density as a string, or "
+                   "atoms_per_unit_cell and volume_of_unit_cell_cm3")
+            raise ValueError(msg)
 
         openmc_material.set_density(
             self.density_unit, self.density * self.packing_fraction
@@ -894,13 +888,9 @@ class Material:
         additional_end_lines: Optional[Dict[str, List[str]]] = None,
     ):
         if sum(fracs) != 1.0:
-            warnings.warn(
-                "warning sum of MutliMaterials.fracs do not sum to 1."
-                + str(fracs)
-                + " = "
-                + str(sum(fracs)),
-                UserWarning,
-            )
+            msg = ("warning sum of MutliMaterials.fracs do not sum to 1."
+                  f"{fracs} = {sum(fracs)}")
+            warnings.warn(msg, UserWarning)
 
         openmc_material_objects = []
         for material in materials:
@@ -909,10 +899,9 @@ class Material:
             elif isinstance(material, Material):
                 openmc_material_objects.append(material.openmc_material)
             else:
-                raise ValueError(
-                    "only openmc.Material or neutronics_material_maker. \
-                    Materials are accepted. Not", type(material),
-                )
+                msg = ("only openmc.Material or neutronics_material_maker."
+                      f"Materials are accepted. Not {type(material)}")
+                raise ValueError(msg)
 
         openmc_material = openmc.Material.mix_materials(
             materials=openmc_material_objects,

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -489,7 +489,8 @@ class Material:
             self._density = value
         elif isinstance(value, (int, float)):
             if value < 0:
-                raise ValueError(f"Material.density should be above 0. Not {value}")
+                raise ValueError(
+                    f"Material.density should be above 0. Not {value}")
             self._density = float(value)
 
     @property
@@ -524,8 +525,9 @@ class Material:
     def enrichment_target(self, value):
         if value is not None:
             if value not in NATURAL_ABUNDANCE.keys():
-                msg = ("Material.enrichment_target must be a naturally occuring "
-                       f"isotope from this list {NATURAL_ABUNDANCE.keys()}")
+                msg = (
+                    "Material.enrichment_target must be a naturally occuring "
+                    f"isotope from this list {NATURAL_ABUNDANCE.keys()}")
                 raise ValueError(msg)
         self._enrichment_target = value
 
@@ -857,10 +859,11 @@ class Material:
         # TODO allow discreat libraries to be searched library: List('str')
 
         if name not in material_dict.keys():
-            closest_match = difflib.get_close_matches(name, material_dict.keys())
+            closest_match = difflib.get_close_matches(
+                name, material_dict.keys())
             msg = f'name of {name} was not found in the internal library.'
             if len(closest_match) > 0:
-                msg = msg +  f' Did you mean {closest_match}?'
+                msg = msg + f' Did you mean {closest_match}?'
             raise ValueError(msg)
 
         entry = material_dict[name].copy()
@@ -889,7 +892,7 @@ class Material:
     ):
         if sum(fracs) != 1.0:
             msg = ("warning sum of MutliMaterials.fracs do not sum to 1."
-                  f"{fracs} = {sum(fracs)}")
+                   f"{fracs} = {sum(fracs)}")
             warnings.warn(msg, UserWarning)
 
         openmc_material_objects = []
@@ -900,7 +903,7 @@ class Material:
                 openmc_material_objects.append(material.openmc_material)
             else:
                 msg = ("only openmc.Material or neutronics_material_maker."
-                      f"Materials are accepted. Not {type(material)}")
+                       f"Materials are accepted. Not {type(material)}")
                 raise ValueError(msg)
 
         openmc_material = openmc.Material.mix_materials(

--- a/neutronics_material_maker/material.py
+++ b/neutronics_material_maker/material.py
@@ -3,6 +3,7 @@
 __author__ = "neutronics material maker development team"
 
 
+import difflib
 import json
 import os
 import re
@@ -862,10 +863,11 @@ class Material:
         # TODO allow discreat libraries to be searched library: List('str')
 
         if name not in material_dict.keys():
-
-            raise ValueError(
-                'name of ', name, 'not found in the internal library'
-            )
+            closest_match = difflib.get_close_matches(name, material_dict.keys())
+            msg = f'name of {name} was not found in the internal library.'
+            if len(closest_match) > 0:
+                msg = msg +  f' Did you mean {closest_match}?'
+            raise ValueError(msg)
 
         entry = material_dict[name].copy()
 

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -153,8 +153,8 @@ def check_add_additional_end_lines(value):
         for key, entries in value.items():
             if key not in string_codes:
                 msg = (f'Material.additional_end_lines should be a dictionary '
-                        'where the keys are the name of the neutronics '
-                        'code. Acceptable values are {string_codes}')
+                       'where the keys are the name of the neutronics '
+                       'code. Acceptable values are {string_codes}')
                 raise ValueError(msg)
             if not isinstance(entries, list):
                 raise ValueError(

--- a/neutronics_material_maker/utils.py
+++ b/neutronics_material_maker/utils.py
@@ -152,21 +152,20 @@ def check_add_additional_end_lines(value):
                 'Material.additional_end_lines should be a dictionary')
         for key, entries in value.items():
             if key not in string_codes:
-                raise ValueError(
-                    'Material.additional_end_lines should be a '
-                    'dictionary where the keys are the name of the neutronics'
-                    'code. Acceptable values are {}'.format(string_codes))
+                msg = (f'Material.additional_end_lines should be a dictionary '
+                        'where the keys are the name of the neutronics '
+                        'code. Acceptable values are {string_codes}')
+                raise ValueError(msg)
             if not isinstance(entries, list):
                 raise ValueError(
-                    'Material.additional_end_lines should be a'
-                    ' dictionary where the value of each dictionary entry is a'
-                    ' list')
+                    'Material.additional_end_lines should be a dictionary '
+                    'where the value of each dictionary entry is a list')
             for entry in entries:
                 if not isinstance(entry, str):
                     raise ValueError(
-                        'Material.additional_end_lines should be'
-                        'a dictionary where the value of each dictionary entry'
-                        ' is a list of strings')
+                        'Material.additional_end_lines should be a dictionary '
+                        'where the value of each dictionary entry is a list '
+                        'of strings')
     return value
 
 
@@ -193,9 +192,8 @@ def make_fispact_material(mat) -> str:
     """
 
     if mat.volume_in_cm3 is None:
-        raise ValueError(
-            "Material.volume_in_cm3 needs setting before fispact_material can be made"
-        )
+        msg = "Material.volume_in_cm3 needs setting before fispact_material can be made"
+        raise ValueError(msg)
 
     mat_card = [
         "DENSITY " + str(mat.openmc_material.get_mass_density()),
@@ -227,11 +225,10 @@ def make_serpent_material(mat) -> str:
     else:
         name = mat.name
 
-    mat_card = ["mat " + name + " " +
-                str(mat.openmc_material.get_mass_density())]
+    mat_card = [f"mat {name} {mat.openmc_material.get_mass_density()}"]
     if mat.temperature_to_neutronics_code is True:
         if mat.temperature is not None:
-            mat_card[0] = mat_card[0] + ' tmp ' + str(mat.temperature)
+            mat_card[0] = mat_card[0] + f' tmp {mat.temperature}'
         # should check if percent type is 'ao' or 'wo'
 
     for isotope in mat.openmc_material.nuclides:
@@ -361,14 +358,14 @@ def AddMaterialFromDir(directory: str, verbose: bool = True, recursive=True):
         filelist = Path(directory).glob("*.json")
     for filename in filelist:
         if verbose is True:
-            print('loading', filename)
+            print(f'loading {filename}')
         AddMaterialFromFile(filename, verbose)
 
 
 def AddMaterialFromFile(filename: str, verbose: Optional[bool] = True) -> None:
     """Add materials to the internal library from a json file"""
     if verbose:
-        print("Added materials to library from", filename)
+        print(f"Added materials to library from {filename}")
     with open(filename, "r") as f:
         new_data = json.load(f)
         if verbose:


### PR DESCRIPTION
This PR makes the package a bit more user friendly by returning suggested materials when the user entered material is not recognised.

for example if someone tries to add "Stainless, Steel blah blah blah" then this won't be recognised but now close matching suggestions like "Stainless, Steel 316" will be in the error message that the user gets.