### PR TITLE
material name hints

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,9 +1,15 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# This yml file will trigger a Github Actions event that builds and upload the
+# Python package to PiPy. This makes use of Twine and is triggered when a push
+# to the main branch occures. For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# and for details on the Autobump version section see:
+# https://github.com/grst/python-ci-versioneer
 
 name: Upload Python Package
 
 on:
+  # allows us to run workflows manually
+  workflow_dispatch:
   release:
     types: [created]
 
@@ -13,19 +19,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Autobump version
+      run: |
+        # from refs/tags/v1.2.3 get 1.2.3
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        PLACEHOLDER='version="develop"'
+        VERSION_FILE='setup.py'
+        # Grep checks that the placeholder is in the file. If grep doesn't find
+        # the placeholder then it exits with exit code 1 and github actions fails.
+        grep "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s@$PLACEHOLDER@version=\"${VERSION}\"@g" "$VERSION_FILE"
+      shell: bash
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -153,17 +153,22 @@ class test_object_properties(unittest.TestCase):
         line_by_line_material = test_mat.fispact_material.split("\n")
 
         assert len(line_by_line_material) == 10
-        assert test_mat.fispact_material.split(
-            "\n")[0].startswith("DENSITY 2.31899993235464")
-        assert test_mat.fispact_material.split("\n")[1] == "FUEL 8"
-        assert "Li6 3.537400925715E+21" in line_by_line_material
-        assert "Li7 4.307481314353E+22" in line_by_line_material
-        assert "Si28 1.074757396925E+22" in line_by_line_material
-        assert "Si29 5.457311411014E+20" in line_by_line_material
-        assert "Si30 3.597484069651E+20" in line_by_line_material
-        assert "O16 4.650130496709E+22" in line_by_line_material
-        assert "O17 1.766602913225E+19" in line_by_line_material
-        assert "O18 9.324307302413E+19" in line_by_line_material
+        assert line_by_line_material[0].startswith("DENSITY 2.31899993235464")
+        assert line_by_line_material[1] == "FUEL 8"
+
+        dict_of_fispact_mats = {}
+        for entry in line_by_line_material:
+            isotope_and_fraction = entry.split()
+            dict_of_fispact_mats[isotope_and_fraction[0]] = float(isotope_and_fraction[1])
+        
+        assert dict_of_fispact_mats['Li6'] == pytest.approx(3.537400925715E+21)
+        assert dict_of_fispact_mats['Li7'] == pytest.approx(4.307481314353E+22)
+        assert dict_of_fispact_mats['Si28'] == pytest.approx(1.074757396925E+22)
+        assert dict_of_fispact_mats['Si29'] == pytest.approx(5.457311411014E+20)
+        assert dict_of_fispact_mats['Si30'] == pytest.approx(3.597484069651E+20)
+        assert dict_of_fispact_mats['O16'] == pytest.approx(4.650130496709E+22)
+        assert dict_of_fispact_mats['O17'] == pytest.approx(1.766602913225E+19)
+        assert dict_of_fispact_mats['O18'] == pytest.approx(9.324307302413E+19)
 
     def test_fispact_material_with_volume(self):
         test_mat = nmm.Material.from_library("Li4SiO4", volume_in_cm3=2.0)
@@ -172,14 +177,20 @@ class test_object_properties(unittest.TestCase):
         assert len(line_by_line_material) == 10
         assert line_by_line_material[0].startswith("DENSITY 2.31899993235464")
         assert line_by_line_material[1] == "FUEL 8"
-        assert "Li6 7.074801851431E+21" in line_by_line_material
-        assert "Li7 8.614962628707E+22" in line_by_line_material
-        assert "Si28 2.149514793849E+22" in line_by_line_material
-        assert "Si29 1.091462282203E+21" in line_by_line_material
-        assert "Si30 7.194968139301E+20" in line_by_line_material
-        assert "O16 9.300260993419E+22" in line_by_line_material
-        assert "O17 3.533205826449E+19" in line_by_line_material
-        assert "O18 1.864861460483E+20" in line_by_line_material
+
+        dict_of_fispact_mats = {}
+        for entry in line_by_line_material:
+            isotope_and_fraction = entry.split()
+            dict_of_fispact_mats[isotope_and_fraction[0]] = float(isotope_and_fraction[1])
+
+        assert dict_of_fispact_mats['Li6'] == pytest.approx(7.074801851431E+21)
+        assert dict_of_fispact_mats['Li7'] == pytest.approx(8.614962628707E+22)
+        assert dict_of_fispact_mats['Si28'] == pytest.approx(2.149514793849E+22)
+        assert dict_of_fispact_mats['Si29'] == pytest.approx(1.091462282203E+21)
+        assert dict_of_fispact_mats['Si30'] == pytest.approx(7.194968139301E+20)
+        assert dict_of_fispact_mats['O16'] == pytest.approx(9.300260993419E+22)
+        assert dict_of_fispact_mats['O17'] == pytest.approx(3.533205826449E+19)
+        assert dict_of_fispact_mats['O18'] == pytest.approx(1.864861460483E+20)
 
     def test_mcnp_material_suffix(self):
         test_material1 = nmm.Material.from_library(

--- a/tests/test_Material.py
+++ b/tests/test_Material.py
@@ -159,13 +159,17 @@ class test_object_properties(unittest.TestCase):
         dict_of_fispact_mats = {}
         for entry in line_by_line_material:
             isotope_and_fraction = entry.split()
-            dict_of_fispact_mats[isotope_and_fraction[0]] = float(isotope_and_fraction[1])
-        
+            dict_of_fispact_mats[isotope_and_fraction[0]
+                                 ] = float(isotope_and_fraction[1])
+
         assert dict_of_fispact_mats['Li6'] == pytest.approx(3.537400925715E+21)
         assert dict_of_fispact_mats['Li7'] == pytest.approx(4.307481314353E+22)
-        assert dict_of_fispact_mats['Si28'] == pytest.approx(1.074757396925E+22)
-        assert dict_of_fispact_mats['Si29'] == pytest.approx(5.457311411014E+20)
-        assert dict_of_fispact_mats['Si30'] == pytest.approx(3.597484069651E+20)
+        assert dict_of_fispact_mats['Si28'] == pytest.approx(
+            1.074757396925E+22)
+        assert dict_of_fispact_mats['Si29'] == pytest.approx(
+            5.457311411014E+20)
+        assert dict_of_fispact_mats['Si30'] == pytest.approx(
+            3.597484069651E+20)
         assert dict_of_fispact_mats['O16'] == pytest.approx(4.650130496709E+22)
         assert dict_of_fispact_mats['O17'] == pytest.approx(1.766602913225E+19)
         assert dict_of_fispact_mats['O18'] == pytest.approx(9.324307302413E+19)
@@ -181,13 +185,17 @@ class test_object_properties(unittest.TestCase):
         dict_of_fispact_mats = {}
         for entry in line_by_line_material:
             isotope_and_fraction = entry.split()
-            dict_of_fispact_mats[isotope_and_fraction[0]] = float(isotope_and_fraction[1])
+            dict_of_fispact_mats[isotope_and_fraction[0]
+                                 ] = float(isotope_and_fraction[1])
 
         assert dict_of_fispact_mats['Li6'] == pytest.approx(7.074801851431E+21)
         assert dict_of_fispact_mats['Li7'] == pytest.approx(8.614962628707E+22)
-        assert dict_of_fispact_mats['Si28'] == pytest.approx(2.149514793849E+22)
-        assert dict_of_fispact_mats['Si29'] == pytest.approx(1.091462282203E+21)
-        assert dict_of_fispact_mats['Si30'] == pytest.approx(7.194968139301E+20)
+        assert dict_of_fispact_mats['Si28'] == pytest.approx(
+            2.149514793849E+22)
+        assert dict_of_fispact_mats['Si29'] == pytest.approx(
+            1.091462282203E+21)
+        assert dict_of_fispact_mats['Si30'] == pytest.approx(
+            7.194968139301E+20)
         assert dict_of_fispact_mats['O16'] == pytest.approx(9.300260993419E+22)
         assert dict_of_fispact_mats['O17'] == pytest.approx(3.533205826449E+19)
         assert dict_of_fispact_mats['O18'] == pytest.approx(1.864861460483E+20)


### PR DESCRIPTION
This PR makes the package a bit more user friendly by returning suggested materials when the user entered material is not recognised.

for example if someone tries to add "Stainless, Steel blah blah blah" then this won't be recognised but now close matching suggestions like "Stainless, Steel 316" will be in the error message that the user gets.

Also converts some strings to f strings