### PR TITLE
Removed `utils.add_additional_end_lines()` print statement

### DIFF
--- a/src/neutronics_material_maker/utils.py
+++ b/src/neutronics_material_maker/utils.py
@@ -469,7 +469,6 @@ def add_additional_end_lines(code: str, mat) -> list:
     and if so returns the additional lines request as a list to be added to the
     end of the existing material card list.
     """
-    print(mat.additional_end_lines)
     if mat.additional_end_lines is not None:
         if code in list(mat.additional_end_lines.keys()):
             return mat.additional_end_lines[code]


### PR DESCRIPTION
The print statement in the additional end lines function of `Utils.py` should be removed as it fills the ouput with unwanted information. 

For example, this will often just log `None` to the terminal for things like the MCNP card formatting:

```python
for key in nmm.AvailableMaterials().keys():
    mat = nmm.Material.from_library(name=key, material_id=1)
    string = mat.mcnp_material
    # do something with it...
```

See #41 for the original issue.